### PR TITLE
Use Windsurf API for updater, verify checksum, and add scheduled package workflow

### DIFF
--- a/.github/workflows/update-package.yml
+++ b/.github/workflows/update-package.yml
@@ -1,0 +1,62 @@
+name: Update Windsurf package
+
+on:
+  schedule:
+    - cron: '0 */8 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Update package files
+        shell: pwsh
+        run: |
+          ./scripts/update.ps1
+
+      - name: Check for changes
+        id: changes
+        shell: pwsh
+        run: |
+          if (git status --porcelain) {
+            "changed=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          } else {
+            "changed=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          }
+
+      - name: Commit changes
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git add -A
+          git commit -m "Update Windsurf package"
+          git pull --rebase
+          git push
+
+      - name: Build package
+        if: steps.changes.outputs.changed == 'true'
+        shell: pwsh
+        run: |
+          $nuspec = Get-ChildItem -Filter "windsurf.*.nuspec" | Select-Object -First 1
+          if (-not $nuspec) { throw "No nuspec found to pack." }
+          choco pack $nuspec.FullName
+
+      - name: Push package
+        if: steps.changes.outputs.changed == 'true'
+        shell: pwsh
+        env:
+          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+        run: |
+          if (-not $env:CHOCOLATEY_API_KEY) { throw "CHOCOLATEY_API_KEY is not set." }
+          $pkg = Get-ChildItem -Filter "windsurf.*.nupkg" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+          if (-not $pkg) { throw "No nupkg found to push." }
+          choco push $pkg.FullName --source https://push.chocolatey.org/ --api-key $env:CHOCOLATEY_API_KEY

--- a/scripts/update.ps1
+++ b/scripts/update.ps1
@@ -1,0 +1,58 @@
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$platform = 'win32-x64-user'
+$channel = 'stable'
+$api = "https://windsurf-stable.codeium.com/api/update/$platform/$channel/latest"
+
+Write-Host "Fetching latest release metadata: $api"
+$meta = Invoke-RestMethod -Uri $api
+$url = $meta.url
+$version = $meta.windsurfVersion
+$expectedSha = $meta.sha256hash
+if (-not $version) {
+  $version = $meta.productVersion
+}
+if (-not $url) {
+  throw 'Installer URL missing from update metadata.'
+}
+if (-not $version) {
+  throw 'Version missing from update metadata.'
+}
+if (-not $expectedSha) {
+  throw 'SHA256 checksum missing from update metadata.'
+}
+Write-Host "Found Windows installer URL: $url"
+Write-Host "Latest version detected: $version"
+
+$out = Join-Path $env:TEMP ("WindsurfUserSetup-x64-$version.exe")
+Write-Host "Downloading installer to compute checksum: $url"
+Invoke-WebRequest -Uri $url -OutFile $out
+$actualSha = (Get-FileHash -Algorithm SHA256 -Path $out).Hash.ToLowerInvariant()
+if ($actualSha -ne $expectedSha.ToLowerInvariant()) {
+  throw "SHA256 mismatch. Expected $expectedSha got $actualSha"
+}
+Remove-Item -Path $out -ErrorAction SilentlyContinue
+
+$checksum = $expectedSha.ToUpperInvariant()
+
+$nuspec = Get-ChildItem -Path $repoRoot -Filter 'windsurf.*.nuspec' | Select-Object -First 1
+if (-not $nuspec) {
+  throw 'No nuspec found to update.'
+}
+
+[xml]$nuspecXml = Get-Content -Path $nuspec.FullName
+$nuspecXml.package.metadata.version = $version
+$nuspecXml.Save($nuspec.FullName)
+
+$newNuspecName = "windsurf.$version.nuspec"
+$newNuspecPath = Join-Path $repoRoot $newNuspecName
+if ($nuspec.Name -ne $newNuspecName) {
+  Move-Item -Path $nuspec.FullName -Destination $newNuspecPath -Force
+}
+
+$installScriptPath = Join-Path $repoRoot 'tools/chocolateyinstall.ps1'
+$installContent = Get-Content -Path $installScriptPath -Raw
+$installContent = $installContent -replace "(?m)^\$url\s*=\s*'.*'\s*$", "\$url        = '$url'"
+$installContent = $installContent -replace "(?m)^\s*checksum\s*=\s*'.*'\s*$", "  checksum      = '$checksum'"
+Set-Content -Path $installScriptPath -Value $installContent -Encoding UTF8


### PR DESCRIPTION
### Motivation
- Replace fragile HTML scraping and redundant downloads by sourcing canonical metadata from the Windsurf update API.
- Ensure package metadata (`version`, `url`, `checksum`) is derived from the published installer to keep Chocolatey packaging accurate.
- Verify the API-provided SHA256 against a computed hash to detect metadata mismatches before publishing. 
- Automate regular package refreshes so updates are applied without manual intervention.

### Description
- Replace the legacy updater with `scripts/update.ps1` that constructs the API URL using `platform` and `channel`, calls the update API via `Invoke-RestMethod`, and reads `url`, `windsurfVersion`/`productVersion`, and `sha256hash`.
- Download the installer to a temporary file and compute `SHA256` using `Get-FileHash`, compare it to the API `sha256hash`, and fail early on mismatch.
- Update the nuspec `package.metadata.version`, rename the nuspec to `windsurf.<version>.nuspec`, and patch `tools/chocolateyinstall.ps1` to set the new `$url` and `checksum` values.
- Add a scheduled GitHub Actions workflow at `.github/workflows/update-package.yml` that runs every 8 hours (and on manual dispatch), runs `./scripts/update.ps1`, commits detected changes, runs `choco pack`, and pushes with `choco push` using `CHOCOLATEY_API_KEY`.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69607d3cdfbc8321857670180dd1b733)