### PR TITLE
Fix PowerShell expansion in update script URL replacement

### DIFF
--- a/scripts/update.ps1
+++ b/scripts/update.ps1
@@ -53,6 +53,6 @@ if ($nuspec.Name -ne $newNuspecName) {
 
 $installScriptPath = Join-Path $repoRoot 'tools/chocolateyinstall.ps1'
 $installContent = Get-Content -Path $installScriptPath -Raw
-$installContent = $installContent -replace "(?m)^\$url\s*=\s*'.*'\s*$", "\$url        = '$url'"
+$installContent = $installContent -replace '(?m)^\$url\s*=\s*''.*''\s*$', "`$url        = '$url'"
 $installContent = $installContent -replace "(?m)^\s*checksum\s*=\s*'.*'\s*$", "  checksum      = '$checksum'"
 Set-Content -Path $installScriptPath -Value $installContent -Encoding UTF8


### PR DESCRIPTION
### Motivation
- The update script was failing because PowerShell expanded variables in the regex/replacement, producing an invalid pattern at runtime.
- The intent is to reliably update `tools/chocolateyinstall.ps1` with a new `url` assignment and `checksum` without accidental interpolation.

### Description
- Use a single-quoted regex pattern for the `-replace` call to prevent PowerShell from interpreting backslashes and dollar signs in the pattern by changing it to `'(?m)^\$url\s*=\s*''.*''\s*$'`.
- Escape the left-hand `$url` in the replacement with a backtick so the assignment left-hand side remains the literal variable name while allowing the right-hand side to be expanded into the actual URL via `"`$url        = '$url'"`.
- The change modifies `scripts/update.ps1` to perform the safe replacement when updating `tools/chocolateyinstall.ps1`.

### Testing
- No automated tests were run for this change.
- A commit was created with the updated script and the repository reflects the modification to `scripts/update.ps1`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960d457322883219df1eca75cdce09e)